### PR TITLE
Fix typo in python/acron/client/__init__.py

### DIFF
--- a/python/acron/client/__init__.py
+++ b/python/acron/client/__init__.py
@@ -212,7 +212,7 @@ def input_parser():
     return main_parser.parse_args()
 
 def sanity_checks(args):
-    """ perfmon sanity checks on given inputs """
+    """ perform sanity checks on given inputs """
     if "schedule" in args and args.schedule is not None:
         try:
             check_schedule(args.schedule)


### PR DESCRIPTION
"perform" was probably meant instead of "perfmon".
@schwicke As this is a mirror, this probably should be included in main repo (GitLab) as well.